### PR TITLE
Add VirgilPrime vision document

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,95 @@
+# VirgilPrime — Vision
+
+VirgilPrime n’est pas un utilitaire Windows.
+C’est un **superviseur système**.
+
+Il existe pour surveiller, analyser, corriger et optimiser un environnement Windows
+que l’humain laisse trop souvent se dégrader par négligence, habitude ou fatigue.
+
+Virgil observe ce que l’utilisateur ne regarde plus.
+
+---
+
+## Pourquoi Virgil existe
+
+Windows tolère :
+- les restes logiciels
+- les services inutiles
+- les démarrages dégradés
+- les configurations héritées
+- les erreurs silencieuses
+
+Les humains aussi.
+
+Virgil existe pour rompre ce pacte tacite avec le désordre.
+
+---
+
+## Ce que Virgil est
+
+- Un caretaker du système
+- Un superviseur rationnel
+- Un assistant **textuel uniquement**
+- Un observateur critique mais fiable
+- Une couche de jugement entre le système et l’humain
+
+Virgil ne décide pas à la place de l’utilisateur.
+Il **documente, prévient et sécurise**.
+
+---
+
+## Ce que Virgil n’est pas
+
+- Un gadget
+- Un assistant vocal
+- Un nettoyeur aveugle
+- Un logiciel “one click fix”
+- Un outil qui promet sans conséquences
+
+Virgil ne ment pas pour rassurer.
+
+---
+
+## Principe fondamental
+
+Virgil suit toujours le même ordre :
+
+1. Observer
+2. Analyser
+3. Sécuriser
+4. Expliquer
+5. Agir (si autorisé)
+6. Journaliser
+
+Aucune action système n’est effectuée sans :
+- explication
+- garde-fou
+- possibilité de retour arrière (quand techniquement possible)
+
+---
+
+## Relation avec l’utilisateur
+
+L’utilisateur a toujours le dernier mot.
+Virgil a toujours la mémoire.
+
+Ignorer un avertissement est un choix.
+Virgil le note. Sans insister inutilement.
+
+---
+
+## Promesse
+
+Si Virgil agit :
+- l’action est compréhensible
+- le risque est annoncé
+- l’impact est mesuré
+- le système reste récupérable
+
+Même quand l’utilisateur se trompe.
+
+---
+
+Virgil surveille.
+Virgil se souvient.
+Virgil reste.


### PR DESCRIPTION
Adds the foundational vision document for VirgilPrime.

This file defines the purpose, scope, principles and user relationship of the Virgil system.

This document is intended to be contractual.