### PR TITLE
Add narration layer (tone policy + Virgil narrator)

### DIFF
--- a/src/ai/dialogue/virgil_narrator.ts
+++ b/src/ai/dialogue/virgil_narrator.ts
@@ -1,0 +1,71 @@
+import { RuleResult } from "../../core/rules/rule_result";
+import { decideTone, ToneDecision, ToneSettings } from "../tone/tone_policy";
+
+export type VirgilMessage = {
+  mood: ToneDecision["mood"];
+  avatarState: ToneDecision["avatarState"];
+  lines: string[];
+  /** Optional single snark line (already filtered by policy). */
+  snark?: string;
+};
+
+function snarkKey(ruleId: string): string {
+  return `snark:${ruleId}`;
+}
+
+function pickSnark(ruleId: string): string | undefined {
+  // Keep these lines short and non-insulting. Target the situation, not the person.
+  const bank: Record<string, string[]> = {
+    STARTUP_TOO_MANY: [
+      "18 applis au démarrage. La patience n'est pas un plan de performance.",
+      "Windows démarre. Lentement. Comme s'il portait tout ton historique de décisions.",
+      "Tu peux garder tout ça au démarrage. Et aussi accepter les conséquences.",
+    ],
+  };
+
+  const lines = bank[ruleId];
+  if (!lines || lines.length === 0) return undefined;
+  return lines[Math.floor(Math.random() * lines.length)];
+}
+
+export function narrate(results: RuleResult[], settings: ToneSettings): VirgilMessage {
+  const tone = decideTone(results, settings);
+
+  const lines: string[] = [];
+
+  if (results.length === 0) {
+    lines.push("Analyse terminée. État acceptable.");
+    if (tone.includeContext) lines.push("Rien d'urgent. Continue à ne pas casser ça.");
+
+    return {
+      mood: tone.mood,
+      avatarState: tone.avatarState,
+      lines,
+    };
+  }
+
+  const worst = results[0];
+  lines.push(`Analyse terminée. Priorité: ${worst.title}.`);
+  lines.push(worst.summary);
+
+  if (tone.includeContext && worst.details?.length) {
+    lines.push(...worst.details);
+  }
+
+  let snark: string | undefined;
+  if (tone.includeSnark) {
+    const key = snarkKey(worst.ruleId);
+    const mem = settings.sessionSnarkMemory;
+    if (!mem || !mem.has(key)) {
+      snark = pickSnark(worst.ruleId);
+      if (snark && mem) mem.add(key);
+    }
+  }
+
+  return {
+    mood: tone.mood,
+    avatarState: tone.avatarState,
+    lines,
+    snark,
+  };
+}

--- a/src/ai/tone/tone_policy.ts
+++ b/src/ai/tone/tone_policy.ts
@@ -1,0 +1,62 @@
+import { RuleResult } from "../../core/rules/rule_result";
+import { VirgilMood } from "./virgil_mood";
+
+export type ToneLevel = "MINIMAL" | "STANDARD" | "NARRATIVE";
+
+export type ToneSettings = {
+  level: ToneLevel;
+  /** If true, allows a short snark line when conditions match. */
+  allowSnark: boolean;
+  /** Prevent repeating the same snark more than once in a session. */
+  sessionSnarkMemory?: Set<string>;
+};
+
+export type ToneDecision = {
+  mood: VirgilMood;
+  avatarState: "REST" | "ANALYSIS" | "ACTION" | "ALERT" | "SUCCESS" | "ERROR";
+  includeContext: boolean;
+  includeSnark: boolean;
+};
+
+export function decideTone(results: RuleResult[], settings: ToneSettings): ToneDecision {
+  const worst = results[0];
+
+  let mood: VirgilMood = "NEUTRAL";
+  let avatarState: ToneDecision["avatarState"] = "REST";
+
+  if (!worst) {
+    return {
+      mood: "SATISFIED",
+      avatarState: "SUCCESS",
+      includeContext: settings.level !== "MINIMAL",
+      includeSnark: false,
+    };
+  }
+
+  switch (worst.severity) {
+    case "CRITICAL":
+      mood = "VIGILANT";
+      avatarState = "ALERT";
+      break;
+    case "HIGH":
+      mood = "SUSPICIOUS";
+      avatarState = "ALERT";
+      break;
+    case "MEDIUM":
+      mood = "VIGILANT";
+      avatarState = "ANALYSIS";
+      break;
+    case "LOW":
+      mood = "NEUTRAL";
+      avatarState = "REST";
+      break;
+    default:
+      mood = "NEUTRAL";
+      avatarState = "REST";
+  }
+
+  const includeContext = settings.level !== "MINIMAL";
+  const includeSnark = Boolean(settings.allowSnark && worst && worst.severity !== "CRITICAL");
+
+  return { mood, avatarState, includeContext, includeSnark };
+}

--- a/src/ai/tone/virgil_mood.ts
+++ b/src/ai/tone/virgil_mood.ts
@@ -1,0 +1,7 @@
+export type VirgilMood =
+  | "NEUTRAL"
+  | "VIGILANT"
+  | "SUSPICIOUS"
+  | "ANNOYED"
+  | "RESIGNED"
+  | "SATISFIED";

--- a/src/dev/runner_with_narration.ts
+++ b/src/dev/runner_with_narration.ts
@@ -1,0 +1,44 @@
+import { MockAnalyzer } from "../core/analysis/mock_analyzer";
+import { RuleRegistry } from "../core/rules/rule_registry";
+import { ActionLog } from "../core/logging/action_log";
+import { DecisionLog } from "../core/logging/decision_log";
+import { VirgilEngine } from "../core/engine/virgil_engine";
+import { StartupTooManyRule } from "../modules/monitoring/rules/startup_too_many.rule";
+import { SystemSnapshot } from "../core/analysis/system_snapshot";
+import { narrate } from "../ai/dialogue/virgil_narrator";
+
+const snapshot: SystemSnapshot = {
+  capturedAt: new Date().toISOString(),
+  startupEntries: Array.from({ length: 18 }).map((_, i) => ({
+    id: String(i + 1),
+    name: `StartupApp${i + 1}`,
+    source: "HKCU_RUN",
+    enabled: true,
+  })),
+};
+
+async function main() {
+  const analyzer = new MockAnalyzer(snapshot);
+  const rules = new RuleRegistry();
+  rules.register(new StartupTooManyRule(12));
+
+  const engine = new VirgilEngine(analyzer, rules, new ActionLog(), new DecisionLog());
+  const report = await engine.runAnalysis({ runAt: new Date().toISOString(), debug: true });
+
+  const sessionSnarkMemory = new Set<string>();
+  const msg = narrate(report.results, { level: "NARRATIVE", allowSnark: true, sessionSnarkMemory });
+
+  console.log("
+=== VIRGIL OUTPUT ===
+");
+  for (const line of msg.lines) console.log(line);
+  if (msg.snark) console.log(`
+${msg.snark}`);
+  console.log(`
+[mood=${msg.mood}] [avatar=${msg.avatarState}]`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds a deterministic narration layer:
- tone policy (mood + avatar state + context/snark toggles)
- narrator that turns RuleResult[] into user-facing lines
- dev runner that demonstrates narration output

This keeps AI/voice separate from the deterministic core.