### PR TITLE
Add Virgil orb avatar (state mapper + demo)

### DIFF
--- a/src/dev/avatar_demo.tsx
+++ b/src/dev/avatar_demo.tsx
@@ -1,0 +1,68 @@
+import React, { useMemo, useState } from "react";
+import { VirgilOrb } from "../ui/avatar/VirgilOrb";
+import { AvatarState } from "../core/state/avatar_state";
+import { VirgilMood } from "../ai/tone/virgil_mood";
+
+const avatarStates: AvatarState[] = [
+  AvatarState.REST,
+  AvatarState.ANALYSIS,
+  AvatarState.ACTION,
+  AvatarState.ALERT,
+  AvatarState.SUCCESS,
+  AvatarState.ERROR,
+];
+
+const moods: VirgilMood[] = [
+  "NEUTRAL",
+  "VIGILANT",
+  "SUSPICIOUS",
+  "ANNOYED",
+  "RESIGNED",
+  "SATISFIED",
+];
+
+export function AvatarDemo() {
+  const [a, setA] = useState<AvatarState>(AvatarState.REST);
+  const [m, setM] = useState<VirgilMood>("NEUTRAL");
+
+  const title = useMemo(() => `Virgil avatar demo: ${a} / ${m}`, [a, m]);
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 16 }}>
+      <h2 style={{ margin: 0 }}>{title}</h2>
+      <p style={{ marginTop: 6, opacity: 0.75 }}>Minimal orb. The real renderer can replace this later.</p>
+
+      <div style={{ display: "flex", gap: 24, alignItems: "center", marginTop: 16 }}>
+        <VirgilOrb avatarState={a} mood={m} size={180} />
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <label>
+            AvatarState
+            <select style={{ marginLeft: 8 }} value={a} onChange={(e) => setA(e.target.value as AvatarState)}>
+              {avatarStates.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            Mood
+            <select style={{ marginLeft: 8 }} value={m} onChange={(e) => setM(e.target.value as VirgilMood)}>
+              {moods.map((mm) => (
+                <option key={mm} value={mm}>
+                  {mm}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <small style={{ opacity: 0.7 }}>
+            Tip: ALERT + SUSPICIOUS looks properly judgemental.
+          </small>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/avatar/VirgilOrb.tsx
+++ b/src/ui/avatar/VirgilOrb.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { AvatarState } from "../../core/state/avatar_state";
+import { VirgilMood } from "../../ai/tone/virgil_mood";
+import { mapAvatarVisualState } from "./avatar_state_mapper";
+
+type Props = {
+  avatarState: AvatarState;
+  mood: VirgilMood;
+  size?: number;
+};
+
+// Minimal, dependency-free orb (SVG) to represent Virgil.
+// Colors/animations are intentionally simple; final styling can be replaced by the real renderer.
+export function VirgilOrb({ avatarState, mood, size = 160 }: Props) {
+  const v = mapAvatarVisualState(avatarState, mood);
+  const r = size / 2;
+  const eyeOffsetX = size * 0.14;
+  const eyeOffsetY = size * 0.02;
+  const eyeR = size * 0.06;
+
+  // “Expressions” are just eye scale/tilt. Keep it subtle.
+  const squint = v.intensity >= 3 ? 0.55 : v.intensity === 2 ? 0.75 : 1;
+  const focus = v.intensity >= 2 ? 1.15 : 1;
+
+  const pulse = {
+    animation: `virgilPulse ${v.pulseMs}ms ease-in-out infinite`,
+    transformOrigin: "50% 50%",
+  } as React.CSSProperties;
+
+  const ring = v.base === AvatarState.ACTION ? 0.12 : v.base === AvatarState.ANALYSIS ? 0.08 : 0.05;
+
+  return (
+    <div style={{ width: size, height: size, display: "inline-block" }} title={`state=${v.base} mood=${v.mood}`}>
+      <style>{`
+        @keyframes virgilPulse {
+          0% { transform: scale(1); opacity: 1; }
+          50% { transform: scale(${1 + ring}); opacity: 0.92; }
+          100% { transform: scale(1); opacity: 1; }
+        }
+      `}</style>
+
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        <g style={pulse}>
+          <circle cx={r} cy={r} r={r * 0.92} fill="#1db954" opacity={0.92} />
+          <circle cx={r} cy={r} r={r * 0.92} fill="#000" opacity={0.08} />
+
+          {/* inner highlight */}
+          <circle cx={r * 0.75} cy={r * 0.7} r={r * 0.35} fill="#fff" opacity={0.08} />
+
+          {/* eyes */}
+          <g transform={`translate(${r - eyeOffsetX}, ${r + eyeOffsetY}) scale(${focus}, ${squint})`}>
+            <circle cx={0} cy={0} r={eyeR} fill="#0b0f0c" opacity={0.95} />
+          </g>
+          <g transform={`translate(${r + eyeOffsetX}, ${r + eyeOffsetY}) scale(${focus}, ${squint})`}>
+            <circle cx={0} cy={0} r={eyeR} fill="#0b0f0c" opacity={0.95} />
+          </g>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/ui/avatar/avatar_state_mapper.ts
+++ b/src/ui/avatar/avatar_state_mapper.ts
@@ -1,0 +1,63 @@
+import { AvatarState } from "../../core/state/avatar_state";
+import { VirgilMood } from "../../ai/tone/virgil_mood";
+
+export type AvatarVisualState = {
+  base: AvatarState;
+  mood: VirgilMood;
+  /** Suggested animation intensity: 0 (calm) .. 3 (urgent). */
+  intensity: 0 | 1 | 2 | 3;
+  /** Suggested pulse speed in ms. */
+  pulseMs: number;
+};
+
+export function mapAvatarVisualState(
+  avatarState: AvatarState,
+  mood: VirgilMood
+): AvatarVisualState {
+  // Conservative defaults.
+  let intensity: AvatarVisualState["intensity"] = 0;
+  let pulseMs = 1800;
+
+  if (avatarState === AvatarState.ANALYSIS) {
+    intensity = 1;
+    pulseMs = 1400;
+  }
+
+  if (avatarState === AvatarState.ACTION) {
+    intensity = 2;
+    pulseMs = 900;
+  }
+
+  if (avatarState === AvatarState.ALERT) {
+    intensity = 3;
+    pulseMs = 550;
+  }
+
+  if (avatarState === AvatarState.SUCCESS) {
+    intensity = 1;
+    pulseMs = 1200;
+  }
+
+  if (avatarState === AvatarState.ERROR) {
+    intensity = 3;
+    pulseMs = 700;
+  }
+
+  // Mood nudges intensity slightly.
+  if (mood === "ANNOYED" || mood === "SUSPICIOUS") {
+    intensity = Math.min(3, (intensity + 1) as 1 | 2 | 3);
+    pulseMs = Math.max(450, Math.floor(pulseMs * 0.85));
+  }
+
+  if (mood === "SATISFIED") {
+    intensity = 0;
+    pulseMs = 2000;
+  }
+
+  return {
+    base: avatarState,
+    mood,
+    intensity,
+    pulseMs,
+  };
+}


### PR DESCRIPTION
Adds a minimal Virgil orb avatar renderer and a state->visual mapper. Includes a small React demo component to validate AvatarState + Mood combinations.

This is intentionally dependency-free and replaceable by the final renderer.