### PR TITLE
Link narration to avatar (linked demo)

### DIFF
--- a/src/dev/linked_demo.tsx
+++ b/src/dev/linked_demo.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+import { MockAnalyzer } from "../core/analysis/mock_analyzer";
+import { RuleRegistry } from "../core/rules/rule_registry";
+import { ActionLog } from "../core/logging/action_log";
+import { DecisionLog } from "../core/logging/decision_log";
+import { VirgilEngine } from "../core/engine/virgil_engine";
+import { StartupTooManyRule } from "../modules/monitoring/rules/startup_too_many.rule";
+import { SystemSnapshot } from "../core/analysis/system_snapshot";
+import { narrate } from "../ai/dialogue/virgil_narrator";
+import { VirgilOrb } from "../ui/avatar/VirgilOrb";
+import { AvatarState } from "../core/state/avatar_state";
+
+type ToneLevel = "MINIMAL" | "STANDARD" | "NARRATIVE";
+
+function buildSnapshot(startupEnabled: number): SystemSnapshot {
+  return {
+    capturedAt: new Date().toISOString(),
+    startupEntries: Array.from({ length: startupEnabled }).map((_, i) => ({
+      id: String(i + 1),
+      name: `StartupApp${i + 1}`,
+      source: "HKCU_RUN",
+      enabled: true,
+    })),
+  };
+}
+
+export function LinkedDemo() {
+  const [startupCount, setStartupCount] = useState(18);
+  const [tone, setTone] = useState<ToneLevel>("NARRATIVE");
+  const [allowSnark, setAllowSnark] = useState(true);
+
+  const sessionSnarkMemory = useMemo(() => new Set<string>(), []);
+
+  const { msg } = useMemo(() => {
+    const snapshot = buildSnapshot(startupCount);
+    const analyzer = new MockAnalyzer(snapshot);
+    const rules = new RuleRegistry();
+    rules.register(new StartupTooManyRule(12));
+
+    const engine = new VirgilEngine(analyzer, rules, new ActionLog(), new DecisionLog());
+
+    // NOTE: This is a demo: runAnalysis returns a promise, but we keep it sync-ish
+    // by using the already-deterministic snapshot and rule. We'll just narrate directly
+    // from the evaluated rules to keep the demo light.
+    const results = rules.evaluate(snapshot);
+    const msg = narrate(results, { level: tone, allowSnark, sessionSnarkMemory });
+
+    return { msg };
+  }, [startupCount, tone, allowSnark, sessionSnarkMemory]);
+
+  // narrator returns avatarState as string union; map it to enum
+  const avatarState = (msg.avatarState as unknown) as AvatarState;
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 16, maxWidth: 820 }}>
+      <h2 style={{ margin: 0 }}>Virgil linked demo</h2>
+      <p style={{ marginTop: 6, opacity: 0.75 }}>Narration (text) drives the orb state in real time.</p>
+
+      <div style={{ display: "flex", gap: 24, alignItems: "flex-start", marginTop: 16 }}>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10 }}>
+          <VirgilOrb avatarState={avatarState} mood={msg.mood} size={180} />
+          <small style={{ opacity: 0.7 }}>[mood={msg.mood}] [avatar={msg.avatarState}]</small>
+        </div>
+
+        <div style={{ flex: 1 }}>
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "center" }}>
+            <label>
+              Startup entries
+              <input
+                style={{ marginLeft: 8, width: 80 }}
+                type="number"
+                min={0}
+                max={60}
+                value={startupCount}
+                onChange={(e) => setStartupCount(Number(e.target.value))}
+              />
+            </label>
+
+            <label>
+              Tone
+              <select style={{ marginLeft: 8 }} value={tone} onChange={(e) => setTone(e.target.value as ToneLevel)}>
+                <option value="MINIMAL">MINIMAL</option>
+                <option value="STANDARD">STANDARD</option>
+                <option value="NARRATIVE">NARRATIVE</option>
+              </select>
+            </label>
+
+            <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <input type="checkbox" checked={allowSnark} onChange={(e) => setAllowSnark(e.target.checked)} />
+              allowSnark
+            </label>
+          </div>
+
+          <div style={{ marginTop: 16, padding: 12, border: "1px solid #ddd", borderRadius: 10 }}>
+            <div style={{ fontWeight: 600, marginBottom: 8 }}>Virgil says</div>
+            {msg.lines.map((l, idx) => (
+              <div key={idx} style={{ marginBottom: 6 }}>{l}</div>
+            ))}
+            {msg.snark && (
+              <div style={{ marginTop: 10, opacity: 0.85 }}><em>{msg.snark}</em></div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/avatar/avatar_state_mapper.ts
+++ b/src/ui/avatar/avatar_state_mapper.ts
@@ -4,9 +4,7 @@ import { VirgilMood } from "../../ai/tone/virgil_mood";
 export type AvatarVisualState = {
   base: AvatarState;
   mood: VirgilMood;
-  /** Suggested animation intensity: 0 (calm) .. 3 (urgent). */
   intensity: 0 | 1 | 2 | 3;
-  /** Suggested pulse speed in ms. */
   pulseMs: number;
 };
 
@@ -14,36 +12,35 @@ export function mapAvatarVisualState(
   avatarState: AvatarState,
   mood: VirgilMood
 ): AvatarVisualState {
-  // Conservative defaults.
   let intensity: AvatarVisualState["intensity"] = 0;
   let pulseMs = 1800;
 
-  if (avatarState === AvatarState.ANALYSIS) {
-    intensity = 1;
-    pulseMs = 1400;
+  switch (avatarState) {
+    case AvatarState.ANALYSIS:
+      intensity = 1;
+      pulseMs = 1400;
+      break;
+    case AvatarState.ACTION:
+      intensity = 2;
+      pulseMs = 900;
+      break;
+    case AvatarState.ALERT:
+      intensity = 3;
+      pulseMs = 550;
+      break;
+    case AvatarState.SUCCESS:
+      intensity = 1;
+      pulseMs = 1200;
+      break;
+    case AvatarState.ERROR:
+      intensity = 3;
+      pulseMs = 700;
+      break;
+    default:
+      intensity = 0;
+      pulseMs = 1800;
   }
 
-  if (avatarState === AvatarState.ACTION) {
-    intensity = 2;
-    pulseMs = 900;
-  }
-
-  if (avatarState === AvatarState.ALERT) {
-    intensity = 3;
-    pulseMs = 550;
-  }
-
-  if (avatarState === AvatarState.SUCCESS) {
-    intensity = 1;
-    pulseMs = 1200;
-  }
-
-  if (avatarState === AvatarState.ERROR) {
-    intensity = 3;
-    pulseMs = 700;
-  }
-
-  // Mood nudges intensity slightly.
   if (mood === "ANNOYED" || mood === "SUSPICIOUS") {
     intensity = Math.min(3, (intensity + 1) as 1 | 2 | 3);
     pulseMs = Math.max(450, Math.floor(pulseMs * 0.85));
@@ -54,10 +51,5 @@ export function mapAvatarVisualState(
     pulseMs = 2000;
   }
 
-  return {
-    base: avatarState,
-    mood,
-    intensity,
-    pulseMs,
-  };
+  return { base: avatarState, mood, intensity, pulseMs };
 }


### PR DESCRIPTION
Adds a linked demo where narration output (mood + avatarState) directly drives the Virgil orb renderer.

Includes a small UI to tweak startup count and tone settings to validate the full pipeline: rules -> narration -> avatar reaction.