### PR TITLE
V1 Windows Startup Analyzer (read-only snapshot)

### DIFF
--- a/src/dev/runner_windows_startup.ts
+++ b/src/dev/runner_windows_startup.ts
@@ -1,0 +1,12 @@
+import { WindowsStartupAnalyzer } from "../modules/monitoring/analyzers/windows_startup/windows_startup_analyzer";
+
+async function main() {
+  const analyzer = new WindowsStartupAnalyzer();
+  const snapshot = await analyzer.capture();
+  console.log(JSON.stringify(snapshot, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/modules/monitoring/analyzers/command_runner.ts
+++ b/src/modules/monitoring/analyzers/command_runner.ts
@@ -1,0 +1,9 @@
+export type CommandResult = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+};
+
+export interface CommandRunner {
+  run(cmd: string, args: string[]): Promise<CommandResult>;
+}

--- a/src/modules/monitoring/analyzers/node_command_runner.ts
+++ b/src/modules/monitoring/analyzers/node_command_runner.ts
@@ -1,0 +1,24 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { CommandResult, CommandRunner } from "./command_runner";
+
+const execFileAsync = promisify(execFile);
+
+export class NodeCommandRunner implements CommandRunner {
+  async run(cmd: string, args: string[]): Promise<CommandResult> {
+    try {
+      const { stdout, stderr } = await execFileAsync(cmd, args, {
+        windowsHide: true,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return { stdout: String(stdout ?? ""), stderr: String(stderr ?? ""), code: 0 };
+    } catch (err: any) {
+      // execFile throws on non-zero exit. Capture best-effort output.
+      return {
+        stdout: String(err?.stdout ?? ""),
+        stderr: String(err?.stderr ?? String(err ?? "")),
+        code: typeof err?.code === "number" ? err.code : 1,
+      };
+    }
+  }
+}

--- a/src/modules/monitoring/analyzers/windows_startup/parsing.ts
+++ b/src/modules/monitoring/analyzers/windows_startup/parsing.ts
@@ -1,0 +1,123 @@
+import { StartupEntry, StartupEntrySource } from "../../../core/analysis/system_snapshot";
+
+// Simple stable hash (FNV-1a 32-bit). Good enough for ids.
+export function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // unsigned
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function makeStartupId(source: StartupEntrySource, key: string): string {
+  return `${source}:${fnv1a(`${source}|${key}`)}`;
+}
+
+/**
+ * Parses `reg query` output lines for Run keys.
+ */
+export function parseRegQueryRunKey(stdout: string, source: StartupEntrySource): StartupEntry[] {
+  const lines = stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const out: StartupEntry[] = [];
+
+  for (const line of lines) {
+    // Skip header lines like: HKEY_CURRENT_USER\...
+    if (line.startsWith("HKEY_")) continue;
+
+    // Expected: <ValueName>    <Type>    <Data>
+    // Sometimes spacing is inconsistent, so split by 2+ spaces.
+    const parts = line.split(/\s{2,}/);
+    if (parts.length < 3) continue;
+
+    const name = parts[0];
+    const type = parts[1];
+    const data = parts.slice(2).join(" ");
+
+    // Only keep string-ish values.
+    if (!/^REG_(SZ|EXPAND_SZ)$/i.test(type)) continue;
+
+    const id = makeStartupId(source, `${name}|${data}`);
+    out.push({
+      id,
+      name,
+      source,
+      enabled: true,
+      // publisher unknown at this stage
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Parses `schtasks /Query /FO CSV /V` output.
+ * We keep only tasks that look like logon/startup triggers.
+ */
+export function parseSchtasksCsv(stdout: string): StartupEntry[] {
+  const lines = stdout.split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) return [];
+
+  // Basic CSV parsing for schtasks output (quotes + commas).
+  const parseCsvLine = (line: string): string[] => {
+    const res: string[] = [];
+    let cur = "";
+    let inQ = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (inQ && line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQ = !inQ;
+        }
+      } else if (ch === "," && !inQ) {
+        res.push(cur);
+        cur = "";
+      } else {
+        cur += ch;
+      }
+    }
+    res.push(cur);
+    return res;
+  };
+
+  const header = parseCsvLine(lines[0]).map((h) => h.trim());
+  const idxName = header.findIndex((h) => /taskname/i.test(h));
+  const idxSchedule = header.findIndex((h) => /schedule type/i.test(h));
+  const idxStatus = header.findIndex((h) => /^status$/i.test(h));
+
+  if (idxName < 0 || idxSchedule < 0) return [];
+
+  const out: StartupEntry[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvLine(lines[i]);
+    const taskName = (cols[idxName] ?? "").trim();
+    const schedule = (cols[idxSchedule] ?? "").trim();
+    const status = idxStatus >= 0 ? (cols[idxStatus] ?? "").trim() : "";
+
+    if (!taskName) continue;
+
+    const scheduleLower = schedule.toLowerCase();
+    // Keep common triggers.
+    const isLogon = scheduleLower.includes("logon") || scheduleLower.includes("log on");
+    const isStartup = scheduleLower.includes("startup") || scheduleLower.includes("boot");
+    if (!isLogon && !isStartup) continue;
+
+    // If status explicitly says Disabled, mark disabled.
+    const enabled = !/disabled/i.test(status);
+
+    const id = makeStartupId("TASK_SCHEDULER", `${taskName}|${schedule}|${status}`);
+    out.push({
+      id,
+      name: taskName,
+      source: "TASK_SCHEDULER",
+      enabled,
+    });
+  }
+
+  return out;
+}

--- a/src/modules/monitoring/analyzers/windows_startup/windows_startup_analyzer.ts
+++ b/src/modules/monitoring/analyzers/windows_startup/windows_startup_analyzer.ts
@@ -1,0 +1,117 @@
+import { Analyzer } from "../../../core/analysis/analyzer";
+import { SystemSnapshot, StartupEntry } from "../../../core/analysis/system_snapshot";
+import { CommandRunner } from "../command_runner";
+import { NodeCommandRunner } from "../node_command_runner";
+import { parseRegQueryRunKey, parseSchtasksCsv, makeStartupId } from "./parsing";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export type WindowsStartupAnalyzerOptions = {
+  runner?: CommandRunner;
+};
+
+function envPath(name: string): string | undefined {
+  const v = process.env[name];
+  return v && v.trim().length ? v : undefined;
+}
+
+async function safeReadDir(dir: string): Promise<string[]> {
+  try {
+    const items = await fs.readdir(dir);
+    return items;
+  } catch {
+    return [];
+  }
+}
+
+function startupFolderEntries(files: string[], folderPath: string, source: "STARTUP_FOLDER"): StartupEntry[] {
+  return files
+    .filter((f) => !f.toLowerCase().endsWith(".ini"))
+    .map((file) => {
+      const full = path.join(folderPath, file);
+      return {
+        id: makeStartupId(source, full),
+        name: file,
+        source,
+        enabled: true,
+      };
+    });
+}
+
+/**
+ * Windows Startup Analyzer (read-only).
+ * Captures startup entries from:
+ * - HKCU/HKLM Run keys
+ * - Startup folders (user + common)
+ * - Task Scheduler (best-effort logon/startup tasks)
+ */
+export class WindowsStartupAnalyzer implements Analyzer {
+  private readonly runner: CommandRunner;
+
+  constructor(opt: WindowsStartupAnalyzerOptions = {}) {
+    this.runner = opt.runner ?? new NodeCommandRunner();
+  }
+
+  async capture(): Promise<SystemSnapshot> {
+    const capturedAt = new Date().toISOString();
+
+    const startupEntries: StartupEntry[] = [];
+
+    // Registry: HKCU Run
+    const hkcu = await this.runner.run("reg", [
+      "query",
+      "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+    ]);
+    if (hkcu.code === 0 && hkcu.stdout) {
+      startupEntries.push(...parseRegQueryRunKey(hkcu.stdout, "HKCU_RUN"));
+    }
+
+    // Registry: HKLM Run
+    const hklm = await this.runner.run("reg", [
+      "query",
+      "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",
+    ]);
+    if (hklm.code === 0 && hklm.stdout) {
+      startupEntries.push(...parseRegQueryRunKey(hklm.stdout, "HKLM_RUN"));
+    }
+
+    // Startup folders
+    const appData = envPath("APPDATA");
+    const programData = envPath("PROGRAMDATA");
+
+    const userStartup = appData
+      ? path.join(appData, "Microsoft", "Windows", "Start Menu", "Programs", "Startup")
+      : undefined;
+
+    const commonStartup = programData
+      ? path.join(programData, "Microsoft", "Windows", "Start Menu", "Programs", "StartUp")
+      : undefined;
+
+    if (userStartup) {
+      const files = await safeReadDir(userStartup);
+      startupEntries.push(...startupFolderEntries(files, userStartup, "STARTUP_FOLDER"));
+    }
+
+    if (commonStartup) {
+      const files = await safeReadDir(commonStartup);
+      startupEntries.push(...startupFolderEntries(files, commonStartup, "STARTUP_FOLDER"));
+    }
+
+    // Task Scheduler
+    const tasks = await this.runner.run("schtasks", ["/Query", "/FO", "CSV", "/V"]);
+    if (tasks.code === 0 && tasks.stdout) {
+      startupEntries.push(...parseSchtasksCsv(tasks.stdout));
+    }
+
+    // Deduplicate by id.
+    const uniq = new Map<string, StartupEntry>();
+    for (const e of startupEntries) {
+      if (!uniq.has(e.id)) uniq.set(e.id, e);
+    }
+
+    return {
+      capturedAt,
+      startupEntries: [...uniq.values()],
+    };
+  }
+}


### PR DESCRIPTION
Implements a real Windows Startup Analyzer (read-only) that captures startup entries from:
- HKCU Run
- HKLM Run
- Startup folders (user + common)
- Task Scheduler (logon/startup best-effort via schtasks CSV)

Includes parsing helpers, a command runner abstraction for testability, and a dev runner to print the snapshot.

No disable actions yet (V1 capture only).